### PR TITLE
update js to show filtering in Craft v4

### DIFF
--- a/src/web/assets/searchit/build/js/ElementFilters.js
+++ b/src/web/assets/searchit/build/js/ElementFilters.js
@@ -2,7 +2,7 @@ var ElementFilters = (function() {
 	"use strict";
 
 	var defaults = {
-		debug: false,
+        debug: false,
 		attributes: {
 			id: 'data-element-filters-id',
 			filters: 'data-element-filters',
@@ -41,7 +41,7 @@ var ElementFilters = (function() {
 
 			// DOM Elements
 			dom.toolbar = elementIndex.$toolbar[0];
-			dom.search = elementIndex.$search[0].closest('.search');
+			dom.search = elementIndex.$search[0].parentNode.querySelector('.search');
 
 			// Listeners
 			dom.toolbar.addEventListener('change', filterHandler, false);
@@ -172,7 +172,7 @@ var ElementFilters = (function() {
 
 				var filters  = getElementFilters(elementIndex.elementType, elementIndex.sourceKey);
 				if(filters) {
-					dom.search.parentNode.insertBefore(filters, dom.search);
+					dom.search.parentNode.parentNode.insertBefore(filters, dom.search.parentNode);
 				}
 			}
 		}
@@ -183,7 +183,7 @@ var ElementFilters = (function() {
 
 				var filters = getElementFilters(dom.preview.getAttribute('data-type'), dom.preview.getAttribute('data-source'));
 				if(filters) {
-					dom.search.parentNode.insertBefore(filters, dom.search);
+					dom.search.parentNode.parentNode.insertBefore(filters, dom.search.parentNode);
 				}
 			}
 		}


### PR DESCRIPTION
Fix layout bug in Craft v4 Plugin Preview and js fault in "normal" entry filter view.

Therefore the plugin is finally compatible with Craft 4.4.